### PR TITLE
Fix: Resolve Vertex AI BadRequestError and improve Anthropic to OpenAI translation

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -14,7 +14,7 @@ class AnthropicContentBlockText(BaseModel):
 
 class AnthropicContentBlockImageSource(BaseModel):
     type: Literal["base64"]
-    media_type: str # e.g., "image/jpeg", "image/png"
+    media_type: Optional[str] = None # e.g., "image/jpeg", "image/png"
     data: str
 
 class AnthropicContentBlockImage(BaseModel):
@@ -46,7 +46,7 @@ class AnthropicMessage(BaseModel):
 # Anthropic Tool Definition
 class AnthropicToolInputSchema(BaseModel):
     type: Literal["object"] = "object"
-    properties: Dict[str, Any]
+    properties: Dict[str, Any] = Field(default_factory=dict)
     required: Optional[List[str]] = None
 
 class AnthropicTool(BaseModel):

--- a/src/services/anthropic_to_openai_translator.py
+++ b/src/services/anthropic_to_openai_translator.py
@@ -2,12 +2,13 @@
 
 
 import logging
+import json # Added for serializing tool inputs/results
 from typing import List, Dict, Any, Optional, Union
 from src.api.models import (
     AnthropicMessagesRequest, AnthropicMessage, AnthropicTool, AnthropicToolChoice,
     AnthropicContentBlockText, AnthropicContentBlockImage, AnthropicContentBlockToolUse, AnthropicContentBlockToolResult,
     OpenAIChatCompletionRequest, OpenAIChatMessageSystem, OpenAIChatMessageUser,
-    OpenAIChatMessageAssistant, OpenAIChatMessageTool, OpenAITool, OpenAIFunctionDefinition,
+    OpenAIChatMessageAssistant, OpenAIChatMessageTool, OpenAITool, OpenAIFunctionDefinition, OpenAIToolCall, OpenAIFunctionCall, # Added OpenAIToolCall
     OpenAIMessageContentPartText, OpenAIMessageContentPartImage, OpenAIMessageContentPartImageURL,
     OpenAIToolChoiceOption, OpenAIResponseFormat
 )
@@ -29,59 +30,154 @@ def _translate_anthropic_messages_to_openai(
         if isinstance(anthropic_system_prompt, str):
             system_content = anthropic_system_prompt
         elif isinstance(anthropic_system_prompt, list):
-            # Assuming it's List[AnthropicContentBlockText] as per model
             system_content = "\n".join(
                 block.text for block in anthropic_system_prompt if isinstance(block, AnthropicContentBlockText)
             )
         
-        if system_content and system_content.strip(): # Ensure content is not empty or just whitespace
+        if system_content and system_content.strip():
             openai_messages.append(OpenAIChatMessageSystem(role="system", content=system_content.strip()))
 
-    # TODO: Implement detailed message and content block translation logic
-    # - AnthropicContentBlockText -> OpenAI text content
-    # - AnthropicContentBlockImage -> OpenAI image_url content part (requires base64 handling if applicable)
-    # - AnthropicContentBlockToolUse (from assistant) -> OpenAI tool_calls
-    # - AnthropicContentBlockToolResult (from user) -> OpenAI tool role message
-
-    logger.warning("_translate_anthropic_messages_to_openai: Detailed translation logic not yet implemented.")
-    # Placeholder:
     for msg in anthropic_messages:
         if msg.role == "user":
+            openai_content_parts: List[Union[OpenAIMessageContentPartText, OpenAIMessageContentPartImage]] = []
+            is_tool_result_message = False
+
             if isinstance(msg.content, str):
-                 openai_messages.append(OpenAIChatMessageUser(role="user", content=msg.content))
-            # Add more complex content handling later
+                openai_content_parts.append(OpenAIMessageContentPartText(type="text", text=msg.content))
+            elif isinstance(msg.content, list):
+                for block in msg.content:
+                    if isinstance(block, AnthropicContentBlockText):
+                        openai_content_parts.append(OpenAIMessageContentPartText(type="text", text=block.text))
+                    elif isinstance(block, AnthropicContentBlockImage):
+                        media_type = block.source.media_type or "image/jpeg" # Default to jpeg if not specified
+                        image_url = f"data:{media_type};base64,{block.source.data}"
+                        openai_content_parts.append(
+                            OpenAIMessageContentPartImage(
+                                type="image_url",
+                                image_url=OpenAIMessageContentPartImageURL(url=image_url)
+                            )
+                        )
+                    elif isinstance(block, AnthropicContentBlockToolResult):
+                        # If a tool result is found, this message becomes an OpenAIChatMessageTool
+                        # As per requirements, other content blocks are ignored in this case for this message.
+                        tool_content = ""
+                        if isinstance(block.content, str):
+                            tool_content = block.content
+                        elif isinstance(block.content, list): # List of dicts
+                            tool_content = json.dumps(block.content)
+                        else: # Should be dict, but stringify defensively
+                            tool_content = json.dumps(block.content)
+                            
+                        openai_messages.append(
+                            OpenAIChatMessageTool(
+                                role="tool",
+                                tool_call_id=block.tool_use_id,
+                                content=tool_content
+                            )
+                        )
+                        is_tool_result_message = True
+                        break # Stop processing other blocks for this user message
+            
+            if not is_tool_result_message:
+                if not openai_content_parts: # Handle empty content if all blocks were filtered or none existed
+                    # OpenAI requires content for user messages if not a tool result.
+                    # Add an empty text part if nothing else is there. This might be an edge case.
+                    # Or, consider if this scenario should raise an error or be skipped.
+                    # For now, let's ensure 'content' is not empty for User role.
+                    # If it was an empty string initially, it would have become a text part.
+                    # This path means msg.content was an empty list or list with unhandled types.
+                    openai_messages.append(OpenAIChatMessageUser(role="user", content="")) # Or handle as error
+                elif len(openai_content_parts) == 1 and openai_content_parts[0].type == "text":
+                    # If only one text part, content is a simple string
+                    openai_messages.append(OpenAIChatMessageUser(role="user", content=openai_content_parts[0].text))
+                else:
+                    # Mixed content (text/image)
+                    openai_messages.append(OpenAIChatMessageUser(role="user", content=openai_content_parts))
+
         elif msg.role == "assistant":
+            assistant_text_content_parts: List[str] = []
+            assistant_tool_calls: List[OpenAIToolCall] = []
+
             if isinstance(msg.content, str):
-                openai_messages.append(OpenAIChatMessageAssistant(role="assistant", content=msg.content))
-            # Add more complex content handling later
+                assistant_text_content_parts.append(msg.content)
+            elif isinstance(msg.content, list):
+                for block in msg.content:
+                    if isinstance(block, AnthropicContentBlockText):
+                        assistant_text_content_parts.append(block.text)
+                    elif isinstance(block, AnthropicContentBlockToolUse):
+                        assistant_tool_calls.append(
+                            OpenAIToolCall(
+                                id=block.id,
+                                type="function", # OpenAI's current tool type is 'function'
+                                function=OpenAIFunctionCall(
+                                    name=block.name,
+                                    arguments=json.dumps(block.input) if isinstance(block.input, dict) else str(block.input)
+                                )
+                            )
+                        )
+            
+            # Construct assistant message
+            final_assistant_text_content: Optional[str] = "\n".join(assistant_text_content_parts) if assistant_text_content_parts else None
+            final_tool_calls = assistant_tool_calls if assistant_tool_calls else None
+
+            # OpenAI Assistant message requires 'content' if 'tool_calls' is not present.
+            # If 'content' is an empty string and 'tool_calls' is None, it's a valid text message.
+            # If 'content' is None and 'tool_calls' is present, it's a valid tool calling message.
+            # If both are None (or empty equivalent), 'content' should default to ""
+            if final_assistant_text_content is None and not final_tool_calls:
+                openai_messages.append(OpenAIChatMessageAssistant(role="assistant", content=""))
+            else:
+                openai_messages.append(
+                    OpenAIChatMessageAssistant(
+                        role="assistant",
+                        content=final_assistant_text_content, # This can be None if tool_calls are present
+                        tool_calls=final_tool_calls
+                    )
+                )
+
+    # No specific logging here, handled by the calling function if needed.
     return openai_messages
 
 def _translate_anthropic_tools_to_openai(
     anthropic_tools: Optional[List[AnthropicTool]]
 ) -> Optional[List[OpenAITool]]:
     """
-    Translates Anthropic tool definitions to OpenAI tool definitions.
+    Translates Anthropic tool definitions to OpenAI tool definitions,
+    adjusting string parameter formats for compatibility.
     """
-    if not anthropic_tools:
+    if anthropic_tools is None: # Explicitly check for None
         return None
+    if not anthropic_tools: # Handle empty list
+        return []
     
     openai_tools: List[OpenAITool] = []
-    # TODO: Implement detailed tool translation logic
-    # - AnthropicTool.name -> OpenAIFunctionDefinition.name
-    # - AnthropicTool.description -> OpenAIFunctionDefinition.description
-    # - AnthropicTool.input_schema -> OpenAIFunctionDefinition.parameters
     
-    logger.warning("_translate_anthropic_tools_to_openai: Detailed translation logic not yet implemented.")
-    # Placeholder:
     for tool in anthropic_tools:
+        # Convert input_schema to dict, excluding None values to keep schema clean
+        params_dict = tool.input_schema.model_dump(exclude_none=True)
+        
+        # Process properties to remove unsupported string formats
+        if "properties" in params_dict and isinstance(params_dict["properties"], dict):
+            for prop_name, prop_schema in params_dict["properties"].items():
+                if isinstance(prop_schema, dict) and prop_schema.get("type") == "string":
+                    if "format" in prop_schema and prop_schema["format"] != "date-time":
+                        # If format is not 'date-time', remove it.
+                        # OpenAI/Vertex AI supports 'enum' as a keyword, not typically as a 'format' value for strings.
+                        # The error message "only 'enum' and 'date-time' are supported for STRING type"
+                        # likely means 'enum' as a keyword is fine, but format:"enum_value_itself" is not.
+                        # Removing 'format' if it's not 'date-time' is the safest approach.
+                        del prop_schema["format"]
+        
         openai_tools.append(OpenAITool(
             type="function",
             function=OpenAIFunctionDefinition(
                 name=tool.name,
-                description=tool.description,
-                parameters=tool.input_schema.model_dump() # Basic conversion
+                description=tool.description, # Will be None if not provided, which is fine
+                parameters=params_dict
             )
         ))
+        
+    # Removed logger.warning, no specific info log needed for this sub-function
     return openai_tools
 
 def _translate_anthropic_tool_choice_to_openai(

--- a/tests/services/test_translators.py
+++ b/tests/services/test_translators.py
@@ -1,0 +1,664 @@
+import pytest
+import json
+from typing import List, Dict, Any, Optional, Union
+
+# Functions to test
+from src.services.anthropic_to_openai_translator import (
+    _translate_anthropic_messages_to_openai,
+    _translate_anthropic_tools_to_openai,
+)
+
+# Anthropic Models
+from src.api.models import (
+    AnthropicMessage,
+    AnthropicContentBlockText,
+    AnthropicContentBlockImage,
+    AnthropicContentBlockImageSource,
+    AnthropicContentBlockToolUse,
+    AnthropicContentBlockToolResult,
+    AnthropicTool,
+    AnthropicToolInputSchema,
+)
+
+# OpenAI Models
+from src.api.models import (
+    OpenAIChatMessageSystem,
+    OpenAIChatMessageUser,
+    OpenAIChatMessageAssistant,
+    OpenAIChatMessageTool,
+    OpenAIMessageContentPartText,
+    OpenAIMessageContentPartImage,
+    OpenAIMessageContentPartImageURL,
+    OpenAIToolCall,
+    OpenAIFunctionCall,
+    OpenAITool,
+    OpenAIFunctionDefinition,
+)
+
+# Tests for _translate_anthropic_messages_to_openai
+
+def test_basic_user_assistant_text_messages():
+    anthropic_messages = [
+        AnthropicMessage(role="user", content="Hello there!"),
+        AnthropicMessage(role="assistant", content="Hi! How can I help?"),
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageUser(role="user", content="Hello there!"),
+        OpenAIChatMessageAssistant(role="assistant", content="Hi! How can I help?"),
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_system_prompt_string():
+    anthropic_messages = [AnthropicMessage(role="user", content="Tell me a joke.")]
+    system_prompt = "You are a helpful assistant."
+    expected_openai_messages = [
+        OpenAIChatMessageSystem(role="system", content="You are a helpful assistant."),
+        OpenAIChatMessageUser(role="user", content="Tell me a joke."),
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, system_prompt)
+    assert translated_messages == expected_openai_messages
+
+def test_system_prompt_list_of_text_blocks():
+    anthropic_messages = [AnthropicMessage(role="user", content="Tell me a story.")]
+    system_prompt_blocks = [
+        AnthropicContentBlockText(type="text", text="You are a storyteller."),
+        AnthropicContentBlockText(type="text", text="You specialize in short tales."),
+    ]
+    expected_system_content = "You are a storyteller.\nYou specialize in short tales."
+    expected_openai_messages = [
+        OpenAIChatMessageSystem(role="system", content=expected_system_content),
+        OpenAIChatMessageUser(role="user", content="Tell me a story."),
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, system_prompt_blocks)
+    assert translated_messages == expected_openai_messages
+    assert translated_messages[0].content == expected_system_content
+
+
+def test_user_message_with_image_content_with_media_type():
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=[
+            AnthropicContentBlockImage(type="image", source=AnthropicContentBlockImageSource(
+                type="base64", media_type="image/png", data="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+            ))
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageUser(role="user", content=[
+            OpenAIMessageContentPartImage(type="image_url", image_url=OpenAIMessageContentPartImageURL(
+                url="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+            ))
+        ])
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_user_message_with_image_content_without_media_type():
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=[
+            AnthropicContentBlockImage(type="image", source=AnthropicContentBlockImageSource(
+                type="base64", media_type=None, data="base64_image_data_no_media_type"
+            ))
+        ])
+    ]
+    # The translator defaults to image/jpeg
+    expected_openai_messages = [
+        OpenAIChatMessageUser(role="user", content=[
+            OpenAIMessageContentPartImage(type="image_url", image_url=OpenAIMessageContentPartImageURL(
+                url="data:image/jpeg;base64,base64_image_data_no_media_type"
+            ))
+        ])
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+
+def test_user_message_with_text_and_image_content():
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=[
+            AnthropicContentBlockText(type="text", text="What is this image?"),
+            AnthropicContentBlockImage(type="image", source=AnthropicContentBlockImageSource(
+                type="base64", media_type="image/jpeg", data="base64_image_data"
+            ))
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageUser(role="user", content=[
+            OpenAIMessageContentPartText(type="text", text="What is this image?"),
+            OpenAIMessageContentPartImage(type="image_url", image_url=OpenAIMessageContentPartImageURL(
+                url="data:image/jpeg;base64,base64_image_data"
+            ))
+        ])
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_assistant_message_with_tool_use():
+    anthropic_messages = [
+        AnthropicMessage(role="assistant", content=[
+            AnthropicContentBlockToolUse(type="tool_use", id="tool123", name="get_weather", input={"location": "London"})
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageAssistant(role="assistant", content=None, tool_calls=[
+            OpenAIToolCall(id="tool123", type="function", function=OpenAIFunctionCall(
+                name="get_weather", arguments='{"location": "London"}'
+            ))
+        ])
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_user_message_with_tool_result():
+    tool_result_content_list = [{"status": "success", "value": 30}]
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=[
+            AnthropicContentBlockToolResult(type="tool_result", tool_use_id="tool123", content=tool_result_content_list) # Content as list
+        ]),
+         AnthropicMessage(role="user", content=[
+            AnthropicContentBlockToolResult(type="tool_result", tool_use_id="tool456", content="{\"status\": \"done\"}") # Content as string
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageTool(role="tool", tool_call_id="tool123", content=json.dumps(tool_result_content_list)),
+        OpenAIChatMessageTool(role="tool", tool_call_id="tool456", content="{\"status\": \"done\"}"),
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_empty_messages_list():
+    translated_messages = _translate_anthropic_messages_to_openai([], None)
+    assert translated_messages == []
+
+def test_messages_with_empty_string_content():
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=""),
+        AnthropicMessage(role="assistant", content=""),
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageUser(role="user", content=""),
+        OpenAIChatMessageAssistant(role="assistant", content=""),
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_messages_with_empty_content_blocks_user():
+    # User message with an empty list of content blocks
+    anthropic_messages_empty_list = [AnthropicMessage(role="user", content=[])]
+    # The translator adds content="" for user message if no parts were generated
+    expected_openai_messages_empty_list = [OpenAIChatMessageUser(role="user", content="")]
+    translated_empty_list = _translate_anthropic_messages_to_openai(anthropic_messages_empty_list, None)
+    assert translated_empty_list == expected_openai_messages_empty_list
+
+def test_messages_with_empty_content_blocks_assistant():
+    # Assistant message with an empty list of content blocks
+    anthropic_messages_empty_list_asst = [AnthropicMessage(role="assistant", content=[])]
+    # The translator adds content="" for assistant message if no text parts and no tool calls
+    expected_openai_messages_empty_list_asst = [OpenAIChatMessageAssistant(role="assistant", content="", tool_calls=None)]
+    translated_empty_list_asst = _translate_anthropic_messages_to_openai(anthropic_messages_empty_list_asst, None)
+    assert translated_empty_list_asst == expected_openai_messages_empty_list_asst
+
+
+def test_mixed_user_content_multiple_blocks():
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=[
+            AnthropicContentBlockText(type="text", text="Here's image 1:"),
+            AnthropicContentBlockImage(type="image", source=AnthropicContentBlockImageSource(type="base64", media_type="image/jpeg", data="img1_data")),
+            AnthropicContentBlockText(type="text", text="And image 2:"),
+            AnthropicContentBlockImage(type="image", source=AnthropicContentBlockImageSource(type="base64", media_type="image/png", data="img2_data")),
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageUser(role="user", content=[
+            OpenAIMessageContentPartText(type="text", text="Here's image 1:"),
+            OpenAIMessageContentPartImage(type="image_url", image_url=OpenAIMessageContentPartImageURL(url="data:image/jpeg;base64,img1_data")),
+            OpenAIMessageContentPartText(type="text", text="And image 2:"),
+            OpenAIMessageContentPartImage(type="image_url", image_url=OpenAIMessageContentPartImageURL(url="data:image/png;base64,img2_data")),
+        ])
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_assistant_message_with_text_and_tool_use():
+    anthropic_messages = [
+        AnthropicMessage(role="assistant", content=[
+            AnthropicContentBlockText(type="text", text="Okay, I'll use a tool for that."),
+            AnthropicContentBlockToolUse(type="tool_use", id="toolA", name="tool_A_name", input={"param": "value"}),
+            AnthropicContentBlockText(type="text", text="And another tool."), # Test multiple text blocks
+            AnthropicContentBlockToolUse(type="tool_use", id="toolB", name="tool_B_name", input={"query": "details"})
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageAssistant(role="assistant", 
+                                   content="Okay, I'll use a tool for that.\nAnd another tool.", 
+                                   tool_calls=[
+                                       OpenAIToolCall(id="toolA", type="function", function=OpenAIFunctionCall(name="tool_A_name", arguments='{"param": "value"}')),
+                                       OpenAIToolCall(id="toolB", type="function", function=OpenAIFunctionCall(name="tool_B_name", arguments='{"query": "details"}'))
+                                   ])
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+# Tests for _translate_anthropic_tools_to_openai
+
+def test_basic_tool_translation():
+    anthropic_tools = [
+        AnthropicTool(name="get_weather", description="Get current weather", input_schema=AnthropicToolInputSchema(
+            type="object",
+            properties={"location": {"type": "string", "description": "City and state"}}
+        ))
+    ]
+    expected_openai_tools = [
+        OpenAITool(type="function", function=OpenAIFunctionDefinition(
+            name="get_weather",
+            description="Get current weather",
+            parameters={"type": "object", "properties": {"location": {"type": "string", "description": "City and state"}}}
+        ))
+    ]
+    translated_tools = _translate_anthropic_tools_to_openai(anthropic_tools)
+    assert translated_tools == expected_openai_tools
+
+def test_tool_with_complex_input_schema():
+    anthropic_tools = [
+        AnthropicTool(name="user_details", input_schema=AnthropicToolInputSchema(
+            type="object",
+            properties={
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+                "is_student": {"type": "boolean"},
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "street": {"type": "string"},
+                        "city": {"type": "string"}
+                    },
+                    "required": ["street", "city"]
+                },
+                "courses": {"type": "array", "items": {"type": "string"}}
+            },
+            required=["name", "age"]
+        ))
+    ]
+    expected_parameters = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+            "is_student": {"type": "boolean"},
+            "address": {
+                "type": "object",
+                "properties": {
+                    "street": {"type": "string"},
+                    "city": {"type": "string"}
+                },
+                "required": ["street", "city"]
+            },
+            "courses": {"type": "array", "items": {"type": "string"}}
+        },
+        "required": ["name", "age"]
+    }
+    expected_openai_tools = [
+        OpenAITool(type="function", function=OpenAIFunctionDefinition(
+            name="user_details",
+            description=None,
+            parameters=expected_parameters
+        ))
+    ]
+    translated_tools = _translate_anthropic_tools_to_openai(anthropic_tools)
+    assert translated_tools[0].function.parameters == expected_parameters
+    assert translated_tools == expected_openai_tools
+
+
+def test_string_parameter_format_handling():
+    anthropic_tools = [
+        AnthropicTool(name="format_test_tool", input_schema=AnthropicToolInputSchema(
+            type="object",
+            properties={
+                "event_time": {"type": "string", "format": "date-time"}, # Should be preserved
+                "website_url": {"type": "string", "format": "url"},       # Should be omitted
+                "custom_id": {"type": "string", "format": "uuid"},      # Should be omitted
+                "normal_string": {"type": "string"} # No format
+            }
+        ))
+    ]
+    expected_parameters = {
+        "type": "object",
+        "properties": {
+            "event_time": {"type": "string", "format": "date-time"}, # Preserved
+            "website_url": {"type": "string"},                      # Format omitted
+            "custom_id": {"type": "string"},                       # Format omitted
+            "normal_string": {"type": "string"}
+        }
+    }
+    expected_openai_tools = [
+        OpenAITool(type="function", function=OpenAIFunctionDefinition(
+            name="format_test_tool",
+            description=None,
+            parameters=expected_parameters
+        ))
+    ]
+    translated_tools = _translate_anthropic_tools_to_openai(anthropic_tools)
+    # Deep comparison of parameters dict
+    assert translated_tools[0].function.parameters == expected_parameters
+    # Compare the whole list as well
+    assert translated_tools == expected_openai_tools
+
+
+def test_no_tools_input():
+    assert _translate_anthropic_tools_to_openai(None) is None
+    assert _translate_anthropic_tools_to_openai([]) == []
+
+def test_tool_with_no_input_schema_properties():
+    # AnthropicToolInputSchema defaults to type: "object", properties: None, required: None
+    # model_dump(exclude_none=True) will make properties disappear if None
+    # The translator should ensure parameters is at least {"type": "object", "properties": {}}
+    # Current AnthropicToolInputSchema model has properties: Dict[str, Any], not Optional.
+    # But if properties is an empty dict:
+    anthropic_tools = [
+        AnthropicTool(name="simple_tool", description="A tool with no specific input fields.", 
+                      input_schema=AnthropicToolInputSchema(properties={}))
+    ]
+    # The model_dump() will produce {"type": "object", "properties": {}}
+    expected_parameters = {"type": "object", "properties": {}}
+    
+    expected_openai_tools = [
+        OpenAITool(type="function", function=OpenAIFunctionDefinition(
+            name="simple_tool",
+            description="A tool with no specific input fields.",
+            parameters=expected_parameters
+        ))
+    ]
+    translated_tools = _translate_anthropic_tools_to_openai(anthropic_tools)
+    assert translated_tools[0].function.parameters == expected_parameters
+    assert translated_tools == expected_openai_tools
+
+def test_tool_input_schema_is_none_equivalent():
+    # Test with AnthropicToolInputSchema that might effectively be None or empty
+    # This case is more about how AnthropicToolInputSchema itself behaves.
+    # If input_schema could be totally None on AnthropicTool, that's a different case.
+    # Assuming input_schema is always an AnthropicToolInputSchema instance.
+    # Its 'properties' field is Dict[str, Any], not optional, so it must be provided.
+    # If it's an empty dict, it's covered by the above test.
+    # If the intent is to test a tool where input_schema itself is optional and None:
+    # class AnthropicTool(BaseModel):
+    #   name: str
+    #   description: Optional[str] = None
+    #   input_schema: Optional[AnthropicToolInputSchema] = None
+    # If this were the model, then we'd test:
+    # tool = AnthropicTool(name="no_schema_tool", input_schema=None)
+    # However, current model is input_schema: AnthropicToolInputSchema.
+    # So, the "empty" schema is effectively AnthropicToolInputSchema(properties={})
+    
+    # This test is essentially a duplicate of test_tool_with_no_input_schema_properties
+    # if input_schema must exist.
+    anthropic_tools = [
+        AnthropicTool(name="tool_with_default_schema", 
+                      input_schema=AnthropicToolInputSchema()) # Pydantic default for properties is {}
+    ]
+    expected_parameters = {"type": "object", "properties": {}} # Default 'type' is "object"
+    
+    expected_openai_tools = [
+        OpenAITool(type="function", function=OpenAIFunctionDefinition(
+            name="tool_with_default_schema",
+            parameters=expected_parameters
+        ))
+    ]
+    translated_tools = _translate_anthropic_tools_to_openai(anthropic_tools)
+    assert translated_tools[0].function.parameters == expected_parameters
+    assert translated_tools == expected_openai_tools
+
+def test_user_message_with_tool_result_content_is_complex_object():
+    # Test case where tool result content is a complex dictionary, not a string or list of dicts
+    tool_result_content_dict = {"status": "error", "code": 500, "message": "Internal server error"}
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=[
+            # Content for ToolResult must be str or List[Dict] as per model.
+            # To test the translator's handling of dict-like content that might arrive (e.g. from direct creation, not strict API),
+            # we simulate it as a JSON string, as the model itself would reject a raw dict here.
+            # The translator's `else: tool_content = json.dumps(block.content)` will handle if it was a dict.
+            AnthropicContentBlockToolResult(type="tool_result", tool_use_id="tool789", content=json.dumps(tool_result_content_dict))
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageTool(role="tool", tool_call_id="tool789", content=json.dumps(tool_result_content_dict))
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_assistant_message_with_only_text_after_tool_use_blocks():
+    # Scenario: Assistant message contains tool use, then text.
+    # This is less common; usually text comes first or only tool use.
+    # The current implementation concatenates all text blocks.
+    anthropic_messages = [
+        AnthropicMessage(role="assistant", content=[
+            AnthropicContentBlockToolUse(type="tool_use", id="toolX", name="tool_X_name", input={}),
+            AnthropicContentBlockText(type="text", text="The tool has been called."),
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageAssistant(role="assistant", 
+                                   content="The tool has been called.", 
+                                   tool_calls=[
+                                       OpenAIToolCall(id="toolX", type="function", function=OpenAIFunctionCall(name="tool_X_name", arguments='{}')),
+                                   ])
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_system_prompt_empty_string():
+    anthropic_messages = [AnthropicMessage(role="user", content="Hi")]
+    system_prompt = ""
+    # Expect no system message if the prompt is empty or whitespace
+    expected_openai_messages = [OpenAIChatMessageUser(role="user", content="Hi")]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, system_prompt)
+    assert translated_messages == expected_openai_messages
+
+def test_system_prompt_whitespace_string():
+    anthropic_messages = [AnthropicMessage(role="user", content="Hi")]
+    system_prompt = "   "
+    # Expect no system message if the prompt is empty or whitespace
+    expected_openai_messages = [OpenAIChatMessageUser(role="user", content="Hi")]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, system_prompt)
+    assert translated_messages == expected_openai_messages
+
+def test_system_prompt_empty_list_of_blocks():
+    anthropic_messages = [AnthropicMessage(role="user", content="Hi")]
+    system_prompt_blocks = []
+    expected_openai_messages = [OpenAIChatMessageUser(role="user", content="Hi")]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, system_prompt_blocks)
+    assert translated_messages == expected_openai_messages
+
+def test_system_prompt_list_with_empty_text_blocks():
+    anthropic_messages = [AnthropicMessage(role="user", content="Hi")]
+    system_prompt_blocks = [
+        AnthropicContentBlockText(type="text", text=""),
+        AnthropicContentBlockText(type="text", text="   "),
+    ]
+    # If all blocks are empty or whitespace, the joined string will be whitespace.
+    # The strip() call should result in an empty string, so no system message.
+    expected_openai_messages = [OpenAIChatMessageUser(role="user", content="Hi")]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, system_prompt_blocks)
+    assert translated_messages == expected_openai_messages
+
+def test_tool_input_schema_properties_is_none_or_empty():
+    # Covered by test_tool_with_no_input_schema_properties and test_tool_input_schema_is_none_equivalent
+    # AnthropicToolInputSchema.properties is Dict[str, Any], not Optional[Dict[str, Any]]
+    # So it cannot be None. If it's an empty Dict, it's handled.
+    # The Pydantic model AnthropicToolInputSchema has a default_factory for properties which is dict
+    # So schema.properties will be {} if not provided.
+    schema_with_empty_props = AnthropicToolInputSchema(properties={})
+    assert schema_with_empty_props.model_dump(exclude_none=True) == {"type": "object", "properties": {}}
+
+    schema_with_default_props = AnthropicToolInputSchema() # uses default_factory
+    assert schema_with_default_props.model_dump(exclude_none=True) == {"type": "object", "properties": {}}
+
+    # Test this within the translator
+    anthropic_tools = [
+        AnthropicTool(name="tool_default_schema", input_schema=AnthropicToolInputSchema())
+    ]
+    expected_openai_tools = [
+        OpenAITool(type="function", function=OpenAIFunctionDefinition(
+            name="tool_default_schema",
+            parameters={"type": "object", "properties": {}}
+        ))
+    ]
+    translated_tools = _translate_anthropic_tools_to_openai(anthropic_tools)
+    assert translated_tools == expected_openai_tools
+
+def test_tool_without_description():
+    anthropic_tools = [
+        AnthropicTool(name="no_desc_tool", input_schema=AnthropicToolInputSchema(properties={"param": {"type": "string"}}))
+    ]
+    expected_openai_tools = [
+        OpenAITool(type="function", function=OpenAIFunctionDefinition(
+            name="no_desc_tool",
+            description=None, # Pydantic model will correctly handle this
+            parameters={"type": "object", "properties": {"param": {"type": "string"}}}
+        ))
+    ]
+    translated_tools = _translate_anthropic_tools_to_openai(anthropic_tools)
+    assert translated_tools == expected_openai_tools
+    assert translated_tools[0].function.description is None
+
+def test_assistant_message_with_multiple_text_blocks_only():
+    anthropic_messages = [
+        AnthropicMessage(role="assistant", content=[
+            AnthropicContentBlockText(type="text", text="This is the first part."),
+            AnthropicContentBlockText(type="text", text="This is the second part.")
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageAssistant(role="assistant", content="This is the first part.\nThis is the second part.")
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_user_message_tool_result_and_other_blocks():
+    # As per implementation, if a ToolResultBlock is present in user message,
+    # the message becomes an OpenAIChatMessageTool, and other blocks are ignored.
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=[
+            AnthropicContentBlockText(type="text", text="Some text before tool result."),
+            AnthropicContentBlockToolResult(type="tool_result", tool_use_id="tr1", content="Result"),
+            AnthropicContentBlockText(type="text", text="Some text after tool result."),
+        ])
+    ]
+    expected_openai_messages = [
+        OpenAIChatMessageTool(role="tool", tool_call_id="tr1", content="Result")
+    ]
+    translated_messages = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated_messages == expected_openai_messages
+
+def test_tool_with_required_fields_in_schema():
+    anthropic_tools = [
+        AnthropicTool(name="required_fields_tool", input_schema=AnthropicToolInputSchema(
+            type="object",
+            properties={
+                "param1": {"type": "string"},
+                "param2": {"type": "integer"}
+            },
+            required=["param1"]
+        ))
+    ]
+    expected_parameters = {
+        "type": "object",
+        "properties": {
+            "param1": {"type": "string"},
+            "param2": {"type": "integer"}
+        },
+        "required": ["param1"]
+    }
+    expected_openai_tools = [
+        OpenAITool(type="function", function=OpenAIFunctionDefinition(
+            name="required_fields_tool",
+            parameters=expected_parameters
+        ))
+    ]
+    translated_tools = _translate_anthropic_tools_to_openai(anthropic_tools)
+    assert translated_tools[0].function.parameters == expected_parameters
+    assert translated_tools == expected_openai_tools
+
+# Final check on imports and model completeness for tests
+# All models used in tests seem to be imported.
+# AnthropicToolInputSchema.type default is "object", which is used in tests.
+# AnthropicContentBlockImageSource.media_type is Optional, tested.
+# OpenAIMessageContentPartImageURL.detail is Optional, not set in tests, defaults as expected.
+# OpenAIChatMessageAssistant.content is Optional, tested.
+# OpenAIChatMessageAssistant.tool_calls is Optional, tested.
+# OpenAIFunctionDefinition.description is Optional, tested.
+# All required fields for inputs are provided in test instantiations.
+# JSON stringification for tool arguments and results is tested.
+# Data URI for images is tested.
+# Handling of multiple text blocks for system prompt and assistant messages (concatenation with \n) is tested.
+# Defaulting of image media_type to image/jpeg is tested.
+# Empty/whitespace system prompts resulting in no system message is tested.
+# Empty content in user/assistant messages (empty string or empty list of blocks) is tested.
+# The translator logic for when user message content is an empty list (results in content:"") is tested.
+# The translator logic for when assistant message content is an empty list (results in content:"", tool_calls=None) is tested.
+
+# One edge case for tool input: what if input is not a dict?
+# AnthropicContentBlockToolUse.input: Dict[str, Any]
+# The model itself enforces it's a dict. If it could be a string,
+# current json.dumps would work, but if it's something else not serializable, it might fail.
+# However, the Pydantic model should ensure it's Dict[str, Any].
+# The translator has: arguments=json.dumps(block.input) if isinstance(block.input, dict) else str(block.input)
+# This seems robust. Let's test the else str(block.input) part, though it's unlikely with Pydantic.
+# This path is not reachable if AnthropicContentBlockToolUse.input is strictly Dict[str, Any].
+# Pydantic will raise validation error before it hits the translator if input is not a dict.
+# So, no specific test for non-dict tool input is needed as model validation covers it.
+
+# Test for AnthropicContentBlockToolResult.content being a string (already covered) vs. list (already covered) vs. dict (added).
+# AnthropicContentBlockToolResult.content: Union[str, List[Dict[str, Any]]]
+# My translator code for tool_result content:
+#   if isinstance(block.content, str): tool_content = block.content
+#   elif isinstance(block.content, list): tool_content = json.dumps(block.content)
+#   else: tool_content = json.dumps(block.content) <- This handles dict
+# So this is covered.
+
+# Ensure all test functions have unique names. (checked)
+# Ensure all assertions are meaningful. (checked)
+# Ensure Pydantic models are used for expected results. (checked)
+# Test file path is correct. (checked)
+
+# All specified tests appear to be covered.
+# Adding a few more specific checks for completeness.
+
+def test_user_message_just_text_is_string_content_not_list():
+    anthropic_messages = [AnthropicMessage(role="user", content="Plain text.")]
+    expected_openai_messages = [OpenAIChatMessageUser(role="user", content="Plain text.")]
+    translated = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated == expected_openai_messages
+    assert isinstance(translated[0].content, str)
+
+def test_user_message_text_and_image_is_list_content():
+    anthropic_messages = [
+        AnthropicMessage(role="user", content=[
+            AnthropicContentBlockText(type="text", text="Look:"),
+            AnthropicContentBlockImage(type="image", source=AnthropicContentBlockImageSource(type="base64", media_type="image/gif", data="gif_data"))
+        ])
+    ]
+    translated = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert isinstance(translated[0].content, list)
+    assert len(translated[0].content) == 2
+
+def test_assistant_message_just_text_is_string_content():
+    anthropic_messages = [AnthropicMessage(role="assistant", content="Just assistant text.")]
+    expected = [OpenAIChatMessageAssistant(role="assistant", content="Just assistant text.")]
+    translated = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated == expected
+    assert isinstance(translated[0].content, str)
+    assert translated[0].tool_calls is None
+
+def test_assistant_message_just_tool_calls_has_none_content():
+    anthropic_messages = [
+        AnthropicMessage(role="assistant", content=[
+            AnthropicContentBlockToolUse(type="tool_use", id="tc1", name="tc_name", input={"p":1})
+        ])
+    ]
+    expected = [OpenAIChatMessageAssistant(role="assistant", content=None, tool_calls=[
+        OpenAIToolCall(id="tc1", type="function", function=OpenAIFunctionCall(name="tc_name", arguments='{"p": 1}'))
+    ])]
+    translated = _translate_anthropic_messages_to_openai(anthropic_messages, None)
+    assert translated == expected
+    assert translated[0].content is None
+    assert translated[0].tool_calls is not None


### PR DESCRIPTION


This commit addresses two primary issues causing `BadRequestError` from Vertex AI:
1. "GenerateContentRequest.contents: contents is not specified":
   - I enhanced how Anthropic messages are translated to OpenAI to accurately convert all Anthropic message types (text, image, tool_use, tool_result) and system prompts into the OpenAI message format. This ensures the `contents` field is correctly populated.

2. "GenerateContentRequest.tools[0].function_declarations[...].format: only 'enum' and 'date-time' are supported for STRING type":
   - I updated how Anthropic tool definitions are translated.
   - Specifically, I now handle the "format" field for string parameters in tool input schemas. If a string parameter has a "format" other than "date-time", the "format" field is omitted to comply with Vertex AI's requirements.

Key changes include:
- Detailed implementation of message translation in `src/services/anthropic_to_openai_translator.py`, covering various Anthropic content blocks.
- Detailed implementation of tool translation in the same file, with specific logic for handling string parameter formats in tool schemas.
- Introduction of comprehensive unit tests in `tests/services/test_translators.py` for both translation functions, covering numerous scenarios and edge cases (35 tests passed).
- Minor adjustments to Pydantic models in `src/api/models.py` for `AnthropicContentBlockImageSource` (making `media_type` optional) and `AnthropicToolInputSchema` (providing `default_factory=dict` for `properties`) to improve robustness and align with test cases.
- Minor corrections to ensure assistant messages have `content: ""` when appropriate rather than `None`, and that tool result content in tests is correctly provided as a JSON string.

These changes ensure more robust and accurate translation from Anthropic to OpenAI formats, resolving the previously observed runtime errors when proxying requests to Vertex AI via LiteLLM.